### PR TITLE
Update evm and retesteth tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,12 @@
 # Copyright 2021 The EVM Benchmarks Authors.
 # SPDX-License-Identifier: Apache-2.0
 
+# Geth evm tool download URL
+EVM_DOWNLOAD_URL := https://gethstore.blob.core.windows.net/builds/geth-alltools-linux-amd64-1.10.25-69568c55.tar.gz
+
+# Retesteth tool download URL
+RETESTETH_DOWNLOAD_URL := http://retesteth.ethdevops.io/release/0.2.2-merge/ubuntu-18.04.3/retesteth-0.2.2-merge-ubuntu-18.04.3
+
 # Directory for tools
 BIN_DIR := bin
 
@@ -38,7 +44,7 @@ ${RETESTETH_CONFIG_DIR}:
 	@echo Generating retesteth config dir at $@
 	${RETESTETH} -- --datadir $@ 2>/dev/null >/dev/null || true
 	@echo Patching t8ntool config with '${EVM}'
-	sed -i 's|/bin/evm|$(abspath ${EVM})|g' $@/t8ntool/start.sh
+	sed -i 's|evm|$(abspath ${EVM})|g' $@/t8ntool/start.sh
 
 # Generate the State Test fillers out of benchmark source files.
 ${TMP_DIR}/%Filler.yml: ${SRC_DIR}/%.yml
@@ -56,13 +62,13 @@ clean:
 # Download the retesteth tool.
 ${RETESTETH}:
 	mkdir -p $(dir $@)
-	curl http://retesteth.ethdevops.io/release/0.2.1-difficulty/ubuntu-18.04.3/retesteth-0.2.1-difficulty-ubuntu-18.04.3 > $@
+	curl ${RETESTETH_DOWNLOAD_URL} > $@
 	chmod +x $@
 
 # Download and extract geth evm tool.
 ${EVM}:
 	mkdir -p ${TMP_DIR}
-	curl https://gethstore.blob.core.windows.net/builds/geth-alltools-linux-amd64-1.10.13-7a0c19f8.tar.gz > ${TMP_DIR}/geth-alltools.tar.gz
+	curl ${EVM_DOWNLOAD_URL} > ${TMP_DIR}/geth-alltools.tar.gz
 	tar -xz -f ${TMP_DIR}/geth-alltools.tar.gz -C ${TMP_DIR}
 	mkdir -p $(dir $@)
 	mv ${TMP_DIR}/geth-alltools-*/evm $@

--- a/benchmarks/main/blake2b_huff.json
+++ b/benchmarks/main/blake2b_huff.json
@@ -2,17 +2,18 @@
     "blake2b_huff" : {
         "_info" : {
             "comment" : "",
-            "filling-rpc-server" : "evm version 1.10.13-stable-7a0c19f8",
-            "filling-tool-version" : "retesteth-0.2.1-difficulty+commit.1ee81863.Linux.g++",
-            "generatedTestHash" : "05038174cec3d42aa1174f2a21e70fb2bd82c27e17653844d636383cd9d7b01f",
+            "filling-rpc-server" : "evm version 1.10.25-stable-69568c55",
+            "filling-tool-version" : "retesteth-0.2.2-testinfo+commit.766b4629.Linux.g++",
+            "generatedTestHash" : "895aa812c5bbc903fd3d527e832f28ab92889d09f0f8b1e4d437b186b7e7cea6",
             "labels" : {
-                "0" : ":label empty",
-                "1" : ":label 2805nulls",
-                "2" : ":label 5610nulls",
-                "3" : ":label 8415nulls",
-                "4" : ":label 65536nulls"
+                "0" : "empty",
+                "1" : "2805nulls",
+                "2" : "5610nulls",
+                "3" : "8415nulls",
+                "4" : "65536nulls"
             },
             "lllcversion" : "Error getting LLLC Version",
+            "solidity" : "Error getting solc Version",
             "source" : "tmp/main/blake2b_huffFiller.yml",
             "sourceHash" : "5526aeaa44e8cd1aad721eca0dcc2721170bbe62c44a2ff696c1009c8d1ac9b8"
         },
@@ -22,6 +23,7 @@
             "currentDifficulty" : "0x01",
             "currentGasLimit" : "0x3b9aca00",
             "currentNumber" : "0x01",
+            "currentRandom" : "0x0000000000000000000000000000000000000000000000000000000000000001",
             "currentTimestamp" : "0x61a8d289",
             "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
         },
@@ -109,6 +111,7 @@
             "gasPrice" : "0x01",
             "nonce" : "0x00",
             "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "sender" : "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
             "to" : "0xbe7c43a580000000000000000000000000000001",
             "value" : [
                 "0x00"

--- a/benchmarks/main/blake2b_shifts.json
+++ b/benchmarks/main/blake2b_shifts.json
@@ -2,16 +2,17 @@
     "blake2b_shifts" : {
         "_info" : {
             "comment" : "",
-            "filling-rpc-server" : "evm version 1.10.13-stable-7a0c19f8",
-            "filling-tool-version" : "retesteth-0.2.1-difficulty+commit.1ee81863.Linux.g++",
-            "generatedTestHash" : "9a5c6067e0f93a632ff093dbc0b66f99ef588c67178bdb14d0c4d8b33e2328f4",
+            "filling-rpc-server" : "evm version 1.10.25-stable-69568c55",
+            "filling-tool-version" : "retesteth-0.2.2-testinfo+commit.766b4629.Linux.g++",
+            "generatedTestHash" : "d4f272a8031cedd2b37215e9754cd5ef0b3924ba85fe8d3043f3c3620eb214d2",
             "labels" : {
-                "0" : ":label 2805nulls",
-                "1" : ":label 5610nulls",
-                "2" : ":label 8415nulls",
-                "3" : ":label 65536nulls"
+                "0" : "2805nulls",
+                "1" : "5610nulls",
+                "2" : "8415nulls",
+                "3" : "65536nulls"
             },
             "lllcversion" : "Error getting LLLC Version",
+            "solidity" : "Error getting solc Version",
             "source" : "tmp/main/blake2b_shiftsFiller.yml",
             "sourceHash" : "37255da9bd9147044a28070070e172c375448bb94f790570e9b6c53d6fdeb97d"
         },
@@ -21,6 +22,7 @@
             "currentDifficulty" : "0x01",
             "currentGasLimit" : "0x3b9aca00",
             "currentNumber" : "0x01",
+            "currentRandom" : "0x0000000000000000000000000000000000000000000000000000000000000001",
             "currentTimestamp" : "0x61a8d289",
             "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
         },
@@ -97,6 +99,7 @@
             "gasPrice" : "0x01",
             "nonce" : "0x00",
             "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "sender" : "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
             "to" : "0xbe7c43a580000000000000000000000000000001",
             "value" : [
                 "0x00"

--- a/benchmarks/main/sha1_divs.json
+++ b/benchmarks/main/sha1_divs.json
@@ -2,17 +2,18 @@
     "sha1_divs" : {
         "_info" : {
             "comment" : "",
-            "filling-rpc-server" : "evm version 1.10.13-stable-7a0c19f8",
-            "filling-tool-version" : "retesteth-0.2.1-difficulty+commit.1ee81863.Linux.g++",
-            "generatedTestHash" : "f49ff7340b4643f586ee7c2c6bb0ad66282361d31c6a6d15c547a4085216f545",
+            "filling-rpc-server" : "evm version 1.10.25-stable-69568c55",
+            "filling-tool-version" : "retesteth-0.2.2-testinfo+commit.766b4629.Linux.g++",
+            "generatedTestHash" : "4e293e69e0fd38315ee8220a0a707ff00bdf4e2b6c7429564bbf1a4b8b0761ed",
             "labels" : {
-                "0" : ":label empty",
-                "1" : ":label 1351",
-                "2" : ":label 2737",
-                "3" : ":label 5311",
-                "4" : ":label 65536"
+                "0" : "empty",
+                "1" : "1351",
+                "2" : "2737",
+                "3" : "5311",
+                "4" : "65536"
             },
             "lllcversion" : "Error getting LLLC Version",
+            "solidity" : "Error getting solc Version",
             "source" : "tmp/main/sha1_divsFiller.yml",
             "sourceHash" : "98871da16d00ffc838ce69b17946e39fd80dd96a8aecf36a56786cb46dbf5abe"
         },
@@ -22,6 +23,7 @@
             "currentDifficulty" : "0x01",
             "currentGasLimit" : "0x3b9aca00",
             "currentNumber" : "0x01",
+            "currentRandom" : "0x0000000000000000000000000000000000000000000000000000000000000001",
             "currentTimestamp" : "0x61a8d289",
             "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
         },
@@ -109,6 +111,7 @@
             "gasPrice" : "0x01",
             "nonce" : "0x00",
             "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "sender" : "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
             "to" : "0xbe7c43a580000000000000000000000000000001",
             "value" : [
                 "0x00"

--- a/benchmarks/main/sha1_shifts.json
+++ b/benchmarks/main/sha1_shifts.json
@@ -2,17 +2,18 @@
     "sha1_shifts" : {
         "_info" : {
             "comment" : "",
-            "filling-rpc-server" : "evm version 1.10.13-stable-7a0c19f8",
-            "filling-tool-version" : "retesteth-0.2.1-difficulty+commit.1ee81863.Linux.g++",
-            "generatedTestHash" : "8b8c00238af14c86bb0e3634ab8e8160dae4e4412c9f064273c118c0697f70ee",
+            "filling-rpc-server" : "evm version 1.10.25-stable-69568c55",
+            "filling-tool-version" : "retesteth-0.2.2-testinfo+commit.766b4629.Linux.g++",
+            "generatedTestHash" : "0e8bead4a375ca95f37a951435c248e5400c1f1c6f2a3e3c8617550b25f30ffc",
             "labels" : {
-                "0" : ":label empty",
-                "1" : ":label 1351",
-                "2" : ":label 2737",
-                "3" : ":label 5311",
-                "4" : ":label 65536"
+                "0" : "empty",
+                "1" : "1351",
+                "2" : "2737",
+                "3" : "5311",
+                "4" : "65536"
             },
             "lllcversion" : "Error getting LLLC Version",
+            "solidity" : "Error getting solc Version",
             "source" : "tmp/main/sha1_shiftsFiller.yml",
             "sourceHash" : "85408476f58f6f2ab8e622874c93bffef15f28b201db10d3d21c86736eabc897"
         },
@@ -22,6 +23,7 @@
             "currentDifficulty" : "0x01",
             "currentGasLimit" : "0x3b9aca00",
             "currentNumber" : "0x01",
+            "currentRandom" : "0x0000000000000000000000000000000000000000000000000000000000000001",
             "currentTimestamp" : "0x61a8d289",
             "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
         },
@@ -109,6 +111,7 @@
             "gasPrice" : "0x01",
             "nonce" : "0x00",
             "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "sender" : "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
             "to" : "0xbe7c43a580000000000000000000000000000001",
             "value" : [
                 "0x00"

--- a/benchmarks/main/weierstrudel.json
+++ b/benchmarks/main/weierstrudel.json
@@ -2,17 +2,18 @@
     "weierstrudel" : {
         "_info" : {
             "comment" : "",
-            "filling-rpc-server" : "evm version 1.10.13-stable-7a0c19f8",
-            "filling-tool-version" : "retesteth-0.2.1-difficulty+commit.1ee81863.Linux.g++",
-            "generatedTestHash" : "b0a6dd0d501e3d77ca7cff9ca896f156977f6d9f42dd056902a6e76bf974478e",
+            "filling-rpc-server" : "evm version 1.10.25-stable-69568c55",
+            "filling-tool-version" : "retesteth-0.2.2-testinfo+commit.766b4629.Linux.g++",
+            "generatedTestHash" : "a51ab37321bb53b49f175b9cd12122aa84c6949ebbbdbce724bd2448a2ee41d5",
             "labels" : {
-                "0" : ":label 0",
-                "1" : ":label 1",
-                "2" : ":label 3",
-                "3" : ":label 9",
-                "4" : ":label 14"
+                "0" : "0",
+                "1" : "1",
+                "2" : "3",
+                "3" : "9",
+                "4" : "14"
             },
             "lllcversion" : "Error getting LLLC Version",
+            "solidity" : "Error getting solc Version",
             "source" : "tmp/main/weierstrudelFiller.yml",
             "sourceHash" : "e071a6420595ed970a0ba35236d621b6cc537f24184e4f76605439d6b2fa504d"
         },
@@ -22,6 +23,7 @@
             "currentDifficulty" : "0x01",
             "currentGasLimit" : "0x3b9aca00",
             "currentNumber" : "0x01",
+            "currentRandom" : "0x0000000000000000000000000000000000000000000000000000000000000001",
             "currentTimestamp" : "0x61a8d289",
             "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
         },
@@ -109,6 +111,7 @@
             "gasPrice" : "0x01",
             "nonce" : "0x00",
             "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "sender" : "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
             "to" : "0xbe7c43a580000000000000000000000000000001",
             "value" : [
                 "0x00"

--- a/benchmarks/micro/JUMPDEST_n0.json
+++ b/benchmarks/micro/JUMPDEST_n0.json
@@ -2,13 +2,14 @@
     "JUMPDEST_n0" : {
         "_info" : {
             "comment" : "",
-            "filling-rpc-server" : "evm version 1.10.13-stable-7a0c19f8",
-            "filling-tool-version" : "retesteth-0.2.1-difficulty+commit.1ee81863.Linux.g++",
-            "generatedTestHash" : "ae57cc63be0da86b96d37ea7d0cef0834ab9d807e773a8e6342db92b6e2c71f2",
+            "filling-rpc-server" : "evm version 1.10.25-stable-69568c55",
+            "filling-tool-version" : "retesteth-0.2.2-testinfo+commit.766b4629.Linux.g++",
+            "generatedTestHash" : "07e5618d674022c45dae86c58bd2d498c4e9214dd49a0e2a9416291672d4babd",
             "labels" : {
-                "0" : ":label empty"
+                "0" : "empty"
             },
             "lllcversion" : "Error getting LLLC Version",
+            "solidity" : "Error getting solc Version",
             "source" : "tmp/micro/JUMPDEST_n0Filler.yml",
             "sourceHash" : "814be59fced8218069a9445e675c71bf223c75acf6c631cdf0112be598c15c25"
         },
@@ -18,6 +19,7 @@
             "currentDifficulty" : "0x01",
             "currentGasLimit" : "0x3b9aca00",
             "currentNumber" : "0x01",
+            "currentRandom" : "0x0000000000000000000000000000000000000000000000000000000000000001",
             "currentTimestamp" : "0x61a8d289",
             "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
         },
@@ -61,6 +63,7 @@
             "gasPrice" : "0x01",
             "nonce" : "0x00",
             "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "sender" : "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
             "to" : "0xbe7c43a580000000000000000000000000000001",
             "value" : [
                 "0x00"

--- a/benchmarks/micro/jump_around.json
+++ b/benchmarks/micro/jump_around.json
@@ -2,13 +2,14 @@
     "jump_around" : {
         "_info" : {
             "comment" : "",
-            "filling-rpc-server" : "evm version 1.10.13-stable-7a0c19f8",
-            "filling-tool-version" : "retesteth-0.2.1-difficulty+commit.1ee81863.Linux.g++",
-            "generatedTestHash" : "461e24c65a4c6fc1f36151da9f5acd038e6bd23f9052da127b9d31bf980de0eb",
+            "filling-rpc-server" : "evm version 1.10.25-stable-69568c55",
+            "filling-tool-version" : "retesteth-0.2.2-testinfo+commit.766b4629.Linux.g++",
+            "generatedTestHash" : "682d204267cf3a3909bf22c063f2c9cde06a917d56f3666bad7ff4c724b3676b",
             "labels" : {
-                "0" : ":label empty"
+                "0" : "empty"
             },
             "lllcversion" : "Error getting LLLC Version",
+            "solidity" : "Error getting solc Version",
             "source" : "tmp/micro/jump_aroundFiller.yml",
             "sourceHash" : "cadfd8a7ee22cbefac3a420cc4c762ca1a3a38ae3346407bd31694acff16c78e"
         },
@@ -18,6 +19,7 @@
             "currentDifficulty" : "0x01",
             "currentGasLimit" : "0x3b9aca00",
             "currentNumber" : "0x01",
+            "currentRandom" : "0x0000000000000000000000000000000000000000000000000000000000000001",
             "currentTimestamp" : "0x61a8d289",
             "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
         },
@@ -61,6 +63,7 @@
             "gasPrice" : "0x01",
             "nonce" : "0x00",
             "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "sender" : "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
             "to" : "0xbe7c43a580000000000000000000000000000001",
             "value" : [
                 "0x00"

--- a/benchmarks/micro/loop_with_many_jumpdests.json
+++ b/benchmarks/micro/loop_with_many_jumpdests.json
@@ -2,13 +2,14 @@
     "loop_with_many_jumpdests" : {
         "_info" : {
             "comment" : "",
-            "filling-rpc-server" : "evm version 1.10.13-stable-7a0c19f8",
-            "filling-tool-version" : "retesteth-0.2.1-difficulty+commit.1ee81863.Linux.g++",
-            "generatedTestHash" : "9df2b4f7790074db8360c81faaed5ddef7a682fcdf970c59c424ef04b4f743b7",
+            "filling-rpc-server" : "evm version 1.10.25-stable-69568c55",
+            "filling-tool-version" : "retesteth-0.2.2-testinfo+commit.766b4629.Linux.g++",
+            "generatedTestHash" : "6705dcf14ca877810b543d471e2e07a0db024405863de069eeddaf29a53531fd",
             "labels" : {
-                "0" : ":label empty"
+                "0" : "empty"
             },
             "lllcversion" : "Error getting LLLC Version",
+            "solidity" : "Error getting solc Version",
             "source" : "tmp/micro/loop_with_many_jumpdestsFiller.yml",
             "sourceHash" : "d6102e691b595ce00d2b0a1009096fe4499d67190aea6358a11b3b993dbad854"
         },
@@ -18,6 +19,7 @@
             "currentDifficulty" : "0x01",
             "currentGasLimit" : "0x3b9aca00",
             "currentNumber" : "0x01",
+            "currentRandom" : "0x0000000000000000000000000000000000000000000000000000000000000001",
             "currentTimestamp" : "0x61a8d289",
             "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
         },
@@ -61,6 +63,7 @@
             "gasPrice" : "0x01",
             "nonce" : "0x00",
             "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "sender" : "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
             "to" : "0xbe7c43a580000000000000000000000000000001",
             "value" : [
                 "0x00"

--- a/benchmarks/micro/memory_grow_mload.json
+++ b/benchmarks/micro/memory_grow_mload.json
@@ -2,16 +2,17 @@
     "memory_grow_mload" : {
         "_info" : {
             "comment" : "",
-            "filling-rpc-server" : "evm version 1.10.13-stable-7a0c19f8",
-            "filling-tool-version" : "retesteth-0.2.1-difficulty+commit.1ee81863.Linux.g++",
-            "generatedTestHash" : "48b3b43977abf4674bc4a2959300294417e37addb7849275e36c35f473451025",
+            "filling-rpc-server" : "evm version 1.10.25-stable-69568c55",
+            "filling-tool-version" : "retesteth-0.2.2-testinfo+commit.766b4629.Linux.g++",
+            "generatedTestHash" : "c37e365d12df01440291d02aaac1bcfb07e000483437a881a8548fc9462359d5",
             "labels" : {
-                "0" : ":label nogrow",
-                "1" : ":label by1",
-                "2" : ":label by16",
-                "3" : ":label by32"
+                "0" : "nogrow",
+                "1" : "by1",
+                "2" : "by16",
+                "3" : "by32"
             },
             "lllcversion" : "Error getting LLLC Version",
+            "solidity" : "Error getting solc Version",
             "source" : "tmp/micro/memory_grow_mloadFiller.yml",
             "sourceHash" : "26894703093bd254278478b0e2568f0a96c6f1a8de47b69149e77bf84f6607b7"
         },
@@ -21,6 +22,7 @@
             "currentDifficulty" : "0x01",
             "currentGasLimit" : "0x3b9aca00",
             "currentNumber" : "0x01",
+            "currentRandom" : "0x0000000000000000000000000000000000000000000000000000000000000001",
             "currentTimestamp" : "0x61a8d289",
             "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
         },
@@ -97,6 +99,7 @@
             "gasPrice" : "0x01",
             "nonce" : "0x00",
             "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "sender" : "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
             "to" : "0xbe7c43a580000000000000000000000000000001",
             "value" : [
                 "0x00"

--- a/benchmarks/micro/memory_grow_mstore.json
+++ b/benchmarks/micro/memory_grow_mstore.json
@@ -2,16 +2,17 @@
     "memory_grow_mstore" : {
         "_info" : {
             "comment" : "",
-            "filling-rpc-server" : "evm version 1.10.13-stable-7a0c19f8",
-            "filling-tool-version" : "retesteth-0.2.1-difficulty+commit.1ee81863.Linux.g++",
-            "generatedTestHash" : "d24c88da01fe9878a699e5845ab41bb61d52107b159c112620dcb5cadcf96a5a",
+            "filling-rpc-server" : "evm version 1.10.25-stable-69568c55",
+            "filling-tool-version" : "retesteth-0.2.2-testinfo+commit.766b4629.Linux.g++",
+            "generatedTestHash" : "3eee38bd60d67ea688a50d30043eb8bd3bcf6ab59aa0bdc1aa7c67167ed440a1",
             "labels" : {
-                "0" : ":label nogrow",
-                "1" : ":label by1",
-                "2" : ":label by16",
-                "3" : ":label by32"
+                "0" : "nogrow",
+                "1" : "by1",
+                "2" : "by16",
+                "3" : "by32"
             },
             "lllcversion" : "Error getting LLLC Version",
+            "solidity" : "Error getting solc Version",
             "source" : "tmp/micro/memory_grow_mstoreFiller.yml",
             "sourceHash" : "682b898d578db8d23f2ae8e756320d2afa73b6d219522a9b9fad49747e5adfc3"
         },
@@ -21,6 +22,7 @@
             "currentDifficulty" : "0x01",
             "currentGasLimit" : "0x3b9aca00",
             "currentNumber" : "0x01",
+            "currentRandom" : "0x0000000000000000000000000000000000000000000000000000000000000001",
             "currentTimestamp" : "0x61a8d289",
             "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
         },
@@ -97,6 +99,7 @@
             "gasPrice" : "0x01",
             "nonce" : "0x00",
             "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "sender" : "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
             "to" : "0xbe7c43a580000000000000000000000000000001",
             "value" : [
                 "0x00"

--- a/benchmarks/micro/signextend.json
+++ b/benchmarks/micro/signextend.json
@@ -2,14 +2,15 @@
     "signextend" : {
         "_info" : {
             "comment" : "",
-            "filling-rpc-server" : "evm version 1.10.13-stable-7a0c19f8",
-            "filling-tool-version" : "retesteth-0.2.1-difficulty+commit.1ee81863.Linux.g++",
-            "generatedTestHash" : "61ddc9cafb2a7669e6d23be86ad85a0f8d51a2ec05af45635662ce3336b0f37b",
+            "filling-rpc-server" : "evm version 1.10.25-stable-69568c55",
+            "filling-tool-version" : "retesteth-0.2.2-testinfo+commit.766b4629.Linux.g++",
+            "generatedTestHash" : "35c3ed9ef476821cd989f35a4976ba824ed73b97143eeab4f9234286d39969dd",
             "labels" : {
-                "0" : ":label zero",
-                "1" : ":label one"
+                "0" : "zero",
+                "1" : "one"
             },
             "lllcversion" : "Error getting LLLC Version",
+            "solidity" : "Error getting solc Version",
             "source" : "tmp/micro/signextendFiller.yml",
             "sourceHash" : "cdc96c71d0d3d447620217f172df80ec92694967ff9186e66a5d9afca61e958c"
         },
@@ -19,6 +20,7 @@
             "currentDifficulty" : "0x01",
             "currentGasLimit" : "0x3b9aca00",
             "currentNumber" : "0x01",
+            "currentRandom" : "0x0000000000000000000000000000000000000000000000000000000000000001",
             "currentTimestamp" : "0x61a8d289",
             "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
         },
@@ -73,6 +75,7 @@
             "gasPrice" : "0x01",
             "nonce" : "0x00",
             "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "sender" : "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
             "to" : "0xbe7c43a580000000000000000000000000000001",
             "value" : [
                 "0x00"

--- a/circle.yml
+++ b/circle.yml
@@ -21,6 +21,9 @@ jobs:
           name: Download geth/evm
           command: make bin/evm
       - run:
+          name: Clean
+          command: make clean
+      - run:
           name: Build benchmarks
           command: make
       - run:


### PR DESCRIPTION
Update go-ethereum evm tool to 1.10.25.
Update retesteth to 0.2.2-merge.